### PR TITLE
Validate Jenkinsfile without saving

### DIFF
--- a/src/main/kotlin/com/github/mikesafonov/jenkins/linter/FileContentReader.kt
+++ b/src/main/kotlin/com/github/mikesafonov/jenkins/linter/FileContentReader.kt
@@ -5,12 +5,15 @@ import com.intellij.openapi.actionSystem.CommonDataKeys
 
 /**
  * @author Mike Safonov
+ * @author Tobias Horst
  */
 class FileContentReader {
     fun read(event: AnActionEvent): FileContent? {
+        val editor = event.getData(CommonDataKeys.EDITOR)
         val virtualFile = event.getData(CommonDataKeys.VIRTUAL_FILE)
-        return if (virtualFile != null) {
-            FileContent(virtualFile.name, String(virtualFile.contentsToByteArray()))
+        return if (editor != null && virtualFile != null) {
+            val document = editor.document
+            FileContent(virtualFile.name, document.text)
         } else {
             null
         }


### PR DESCRIPTION
Saving the Jenkinsfile was required to validate it. Otherwise the old content of the file was used for validation.

This PR introduces validation of Jenkinsfiles without saving it. The validation is done against the content of the active editor window which improves the user experience a lot. 