### PR TITLE
Support all newer IntelliJ versions by default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -183,16 +183,14 @@ jobs:
         run: |
           PROPERTIES="$(./gradlew properties --console=plain -q)"
           PLUGIN_SINCE_BUILD="$(echo "$PROPERTIES" | grep "^pluginSinceBuild:" | base64)"
-          PLUGIN_UNTIL_BUILD="$(echo "$PROPERTIES" | grep "^pluginUntilBuild:" | base64)"
           echo "::set-output name=pluginSinceBuild::$PLUGIN_SINCE_BUILD"
-          echo "::set-output name=pluginUntilBuild::$PLUGIN_UNTIL_BUILD"
           echo "::set-output name=pluginVerifierHomeDir::~/.pluginVerifier"
       # Cache Plugin Verifier IDEs
       - name: Setup Plugin Verifier IDEs Cache
         uses: actions/cache@v4.2.0
         with:
           path: ${{ steps.properties.outputs.pluginVerifierHomeDir }}/ides
-          key: ${{ runner.os }}-plugin-verifier-${{ steps.properties.outputs.pluginSinceBuild }}-${{ steps.properties.outputs.pluginUntilBuild }}
+          key: ${{ runner.os }}-plugin-verifier-${{ steps.properties.outputs.pluginSinceBuild }}
 
       # Run IntelliJ Plugin Verifier action using GitHub Action
       - name: Verify Plugin

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,6 @@ pluginVersion = 1.0.1
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 243
-pluginUntilBuild =
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IC

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginVersion = 1.0.1
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 243
-pluginUntilBuild = 243.*
+pluginUntilBuild =
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IC


### PR DESCRIPTION
Currently the build is limited to support IntelliJ Version 24.3.x. Remove that limitation to support all newer IntelliJ versions.